### PR TITLE
remove options after plugin has been deactivated

### DIFF
--- a/browserid.php
+++ b/browserid.php
@@ -143,7 +143,8 @@ if (!class_exists('MozillaPersona')) {
 
 		// Handle plugin deactivation
 		function Deactivate() {
-			// TODO: delete options
+			if(get_option('browserid_options'))
+                delete_option('browserid_options');
 		}
 
 		// Add a "Settings" link to the plugin list page.


### PR DESCRIPTION
Hi :)
When I checked the code I found the TODO which say that need to delete the plugin options when plugin is deactivated. So, I added a little bit code and I hope this well. 

Sorry me for bad English
