### PR TITLE
Disable error reporting

### DIFF
--- a/browserid.php
+++ b/browserid.php
@@ -29,8 +29,6 @@ Original Author URI: http://blog.bokhorst.biz/about/
 	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
-error_reporting(E_ALL);
-
 // Check PHP version
 if (version_compare(PHP_VERSION, '5.0.0', '<'))
 	die('Mozilla Persona requires at least PHP 5, installed version is ' . PHP_VERSION);


### PR DESCRIPTION
Activating this plugin currently spams strictness warnings in PHP 5.3.
