### PR TITLE
Fix documentation

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -56,7 +56,7 @@ Now you will see a red 'Sign in with Persona' button instead of the traditional 
 
 = Which server verifies the assertion? =
 
-The assertion is verified by the server at https://login.persona.org/verify.
+The assertion is verified by the server at https://verifier.login.persona.org/verify.
 
 = I get 'Login failed' =
 


### PR DESCRIPTION
https://login.persona.org/verify was disabled a while ago[1] and the current code is using https://verifier.login.persona.org/verify.

[1] https://mail.mozilla.org/pipermail/persona-notices/2012/000002.html
